### PR TITLE
Fix Base62 decode logic

### DIFF
--- a/Base62.cpp
+++ b/Base62.cpp
@@ -86,7 +86,7 @@ std::string Base62::Base62Decode(std::string strSrc)
     int nLen = strSrc.size();
     unsigned char aryChar4[4];
     unsigned char aryChar3[3];
-    std::string strDir = "\0";
+    std::string strDir;
 
     while (nLen-- 
         && !(strSrc[nSrc] == chCodeFlag 
@@ -145,7 +145,7 @@ std::string Base62::Base62Decode(std::string strSrc)
         {
             if (aryChar4[j] >= 128)
             {
-                aryChar4[j] = strCodes.find(aryChar4[i] - 128);
+                aryChar4[j] = strCodes.find(aryChar4[j] - 128);
                 aryChar4[j] += 61;
             }
             else


### PR DESCRIPTION
## Summary
- remove extra null character prefix in decode output
- fix incorrect index when decoding flagged characters

## Testing
- `g++ Test.cpp Base62.cpp -o test && ./test > /tmp/out.txt && tail -n 2 /tmp/out.txt`

------
https://chatgpt.com/codex/tasks/task_e_683f4e3e06188321a35575bc6576fa1b